### PR TITLE
Customize `List` component

### DIFF
--- a/List.es6
+++ b/List.es6
@@ -15,7 +15,7 @@ import uniq from 'lodash/array/uniq'
 import {KEYS, KEY} from './keys'
 import ListItem from './ListItem'
 
-let MakeList = () => {
+let MakeList = ({keyboardEvents=true}={}) => {
 
 	let List = React.createClass({
 		getDefaultProps() {
@@ -203,7 +203,7 @@ let MakeList = () => {
 
 			return <ul className={cx('react-list-select', this.props.className)}
 				tabIndex={0}
-				onKeyDown={this.onKeyDown}>
+				onKeyDown={keyboardEvents && this.onKeyDown}>
 				{items}
 			</ul>
 		}

--- a/example/index.es6
+++ b/example/index.es6
@@ -1,5 +1,5 @@
 import React from 'react'
-import List from '../index'
+import List, { MakeList } from '../index'
 import values from 'lodash/object/values'
 
 /*
@@ -54,12 +54,25 @@ var comps = [
 
 var example4 = <List items={comps} disabled={[2]} selected={[0]} onChange={console.log.bind(console)} />
 
+
+/*
+	EXAMPLE 5
+*/
+
+var CustomList = MakeList({
+	keyboardEvents: false,
+});
+
+var example5 = <CustomList items={comps} disabled={[2]} selected={[0]} onChange={console.log.bind(console)} />
+
+
 var Demo = React.createClass({
 	render() {
 		return <div className='demo'>
 			<div>{example1} {example1multi}</div>
 			<div className='context-menu'>{example3}</div>
 			<div>{example4}</div>
+			<div>{example5}</div>
 		</div>
 	}
 })

--- a/index.es6
+++ b/index.es6
@@ -1,3 +1,4 @@
-import List from './List'
+import List, { MakeList } from './List'
 
 export default List
+export { MakeList }


### PR DESCRIPTION
This adds the possiblity to customize some of the behaviors of the `List` component :
- component definition is wrapped in a builder function
- builder function takes options that affect the component definition

One option implemented here :
- `keyboardEvents` : Defaults to `true`. If set to `false` the `List` component will not listen for keyboard events. You can still listen for keyboard events yourself and forward the event to the `onKeyDown` function.

Existing default export is not broken, just added optional `MakeList` function to the exported values, as shown in `index.es6`.

The diff for b88c2d2 is ugly, but all I did really was wrapping all the `React.createClass` call in a function which return the component. I did not change anything to the `React.createClass` call in that commit (use `git diff -b` to have the differ ignore the indentation changes).