### PR TITLE
Fixed onKeyDown error

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -307,7 +307,7 @@ export default class List extends React.Component<Props, State> {
 			<ul
 				className={cx('react-list-select', this.props.className)}
 				tabIndex={0}
-				onKeyDown={this.props.keyboardEvents && this.onKeyDown}
+				onKeyDown={this.props.keyboardEvents ? this.onKeyDown : undefined}
 			>
 				{items}
 			</ul>


### PR DESCRIPTION
According to react error:

>  Warning: Expected `onKeyDown` listener to be a function, instead got `false`.
> 
> If you used to conditionally omit it with onKeyDown={condition && value}, pass onKeyDown={condition ? value : undefined} instead.